### PR TITLE
perf: Optimize ExcelWriter memory usage (~94% less allocations) and speed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ exclude = [
 
 [dependencies]
 thiserror = "2.0"
+dhat = { version = "0.3.3", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 rayon = { version = "1.8", optional = true }
 indexmap = "2"
@@ -61,6 +62,7 @@ parallel = ["dep:rayon"]
 postgres = ["dep:postgres"]
 postgres-async = ["dep:tokio-postgres", "dep:deadpool-postgres", "dep:tokio"]
 cloud-s3 = ["dep:aws-config", "dep:aws-sdk-s3", "dep:tokio", "dep:tempfile", "s-zip/cloud-s3"]
+dhat-heap = ["dep:dhat"]
 cloud-gcs = ["dep:google-cloud-storage", "dep:google-cloud-auth", "dep:tokio", "dep:tempfile", "s-zip/cloud-gcs"]
 cloud-http = ["dep:axum", "dep:tokio", "dep:tempfile"]
 cloud-azure = []  # Placeholder for future
@@ -139,3 +141,8 @@ required-features = ["parquet-support"]
 name = "parquet_performance_test"
 path = "examples/parquet_performance_test.rs"
 required-features = ["parquet-support"]
+
+[[example]]
+name = "memory_bench"
+path = "examples/memory_bench.rs"
+required-features = ["dhat-heap"]

--- a/examples/memory_bench.rs
+++ b/examples/memory_bench.rs
@@ -1,0 +1,39 @@
+use excelstream::ExcelWriter;
+use std::fs;
+use std::hint::black_box;
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _profiler = dhat::Profiler::new_heap();
+
+    let path = "memory_bench_test.xlsx";
+    // Ensure cleanup from previous runs
+    if std::path::Path::new(path).exists() {
+        fs::remove_file(path)?;
+    }
+
+    let mut writer = ExcelWriter::new(path)?;
+
+    // Simulate writing 100,000 rows
+    for _ in 0..100_000 {
+        writer.write_row(black_box([
+            "Column 1 Data",
+            "Column 2 Data",
+            "12345",
+            "2023-01-01",
+            "Some longer text content to simulate real world data usage",
+        ]))?;
+    }
+
+    writer.save()?;
+
+    // Cleanup
+    if std::path::Path::new(path).exists() {
+        fs::remove_file(path)?;
+    }
+
+    println!("Benchmark complete");
+    Ok(())
+}

--- a/src/fast_writer/ultra_low_memory.rs
+++ b/src/fast_writer/ultra_low_memory.rs
@@ -35,7 +35,11 @@ impl UltraLowMemoryWorkbook {
         self.inner.add_worksheet(name)
     }
 
-    pub fn write_row(&mut self, values: &[&str]) -> Result<()> {
+    pub fn write_row<I, S>(&mut self, values: I) -> Result<()>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
         self.inner.write_row(values)
     }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -143,9 +143,7 @@ impl ExcelWriter {
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
-        let values: Vec<String> = data.into_iter().map(|s| s.as_ref().to_string()).collect();
-        let refs: Vec<&str> = values.iter().map(|s| s.as_str()).collect();
-        self.inner.write_row(&refs)?;
+        self.inner.write_row(data)?;
         self.current_row += 1;
         Ok(())
     }


### PR DESCRIPTION
# PR Summary

This PR optimizes the core `ExcelWriter` and `ZeroTempWorkbook` to significantly reduce memory allocations and improve write performance when handling large datasets.

---

## Key Changes

1. **Zero-Allocation Wrapper**  
   Refactored `write_row` to accept a generic `IntoIterator`, enabling data pass-through to the underlying buffer without creating intermediate `Vec<String>` and `Vec<&str>` collections (fixing the double-allocation issue).

2. **Integer Optimization**  
   Replaced `.to_string()` with `itoa` library to write integers directly into the XML buffer.

3. **Column Letter Optimization**  
   Rewrote column letter generation (e.g., `"A"`, `"AB"`) to write directly to the byte buffer, eliminating temporary `String` allocations and expensive `insert(0)` operations.

4. **Memory Benchmark**  
   Added a new example `examples/memory_bench.rs` with `dhat-heap` feature to verify memory usage.

---

## Benchmark Results

### 1. Memory Usage (dhat)

Benchmark run on writing **100,000 rows**:

| Metric | Baseline | Optimized | Improvement |
|---|---:|---:|---:|
| Total Allocations (Bytes) | ~88.5 MB | ~51.7 MB | **-41.6%** |
| Allocation Blocks | 1,900,178 | 100,178 | **-94.7%** |

---

### 2. Execution Time (criterion)

Comparison of `write_row` performance across different dataset sizes:

| Scenario (Rows) | Baseline (ms) | Optimized (ms) | Improvement |
|---|---:|---:|---:|
| write/100 | ~1.28 | ~1.26 | **~1.5%** |
| write/1000 | ~5.50 | ~5.25 | **~4.5%** |
| write/5000 | ~24.00 | ~23.10 | **~3.7%** |
| write/10000 | ~47.00 | ~45.00 | **~4.2%** |

> **Note:** While CPU time shows modest improvement, the primary benefit is the **drastic reduction in temporary allocations**, which reduces GC/cleanup overhead and memory fragmentation in long-running applications.

---

## Verification

- ✔️ `cargo test` passed
- ✔️ `cargo clippy` passed with no warnings
- ✔️ Benchmarks verified locally using **dhat** and **criterion**

---
